### PR TITLE
better gnome integration for gentoo bug 443918 (if gnome-settings-manager is not installed, fail gracefully)

### DIFF
--- a/spotify-dbus.py
+++ b/spotify-dbus.py
@@ -52,7 +52,7 @@ class Spotify:
 	size = '48x48'
 	loop = False
 	dloop = False
-	debug = True
+	debug = False
 	cache = os.environ['HOME'] + '/.cache/spotify/Covers/'
 	locale = 'en_US'
 	player = False
@@ -490,12 +490,16 @@ class Spotify:
 
 	# Media keys
 	def install_mediakey_handler(self):
-		bus_object = self.bus.get_object(
-			'org.gnome.SettingsDaemon', '/org/gnome/SettingsDaemon/MediaKeys')
-		bus_object.GrabMediaPlayerKeys(
-			'Spotify', 0, dbus_interface='org.gnome.SettingsDaemon.MediaKeys')
-		bus_object.connect_to_signal(
-			'MediaPlayerKeyPressed', self.handle_mediakey)
+        try:
+            bus_object = self.bus.get_object(
+                'org.gnome.SettingsDaemon', '/org/gnome/SettingsDaemon/MediaKeys')
+            bus_object.GrabMediaPlayerKeys(
+                'Spotify', 0, dbus_interface='org.gnome.SettingsDaemon.MediaKeys')
+            bus_object.connect_to_signal(
+                'MediaPlayerKeyPressed', self.handle_mediakey)
+        except dbus.DBusException:
+            if self.debug:
+                print("Failed to install media key handler (gnome settings daemon not available?)")
 	
 	def handle_mediakey(self, *mmkeys):
 		for key in mmkeys:


### PR DESCRIPTION
More or less says what it does, it just adds a try statement.  I also disabled debug, for end users that generally is not needed.
