### PR TITLE
Pull request for issue 3

### DIFF
--- a/spotify-dbus.py
+++ b/spotify-dbus.py
@@ -410,12 +410,13 @@ class Spotify:
 			output = commands.getoutput('curl -v ' + url + '| grep \'property="og:image"\'')
 			match = re.search('http(.+)image\/(\w+)', output)
 	
-			# Download the cover
-			if self.debug == True:
-				print "Downloading cover " + url + "..."
-	
-			os.system('wget -q -O ' + path + ' ' + match.group(0))
-			os.system('convert -quiet -resize ' + self.size + ' ' + path + ' ' + path)
+			if match is not None:
+				# Download the cover
+				if self.debug == True:
+					print "Downloading cover " + url + "..."
+		
+				os.system('wget -q -O ' + path + ' ' + match.group(0))
+				os.system('convert -quiet -resize ' + self.size + ' ' + path + ' ' + path)
 	
 			# If download fails uses default Spotify icon
 			if not os.path.exists(path):


### PR DESCRIPTION
I'm afraid the issue 3 has returned..

```
Traceback (most recent call last):
  File "/usr/bin/spotify-dbus.py", line 295, in change_listener
    self.show_playing()
  File "/usr/bin/spotify-dbus.py", line 137, in show_playing
    self.nid = interface.Notify('Spotify', 0, self.get_cover(), self.get_info(track, 'title'), text, actions, hints, self.timeout)
  File "/usr/bin/spotify-dbus.py", line 417, in get_cover
    os.system('wget -q -O ' + path + ' ' + match.group(0))
AttributeError: 'NoneType' object has no attribute 'group'
```

I'm using the gentoo version equivalent to 20130119 .

Interrestengly, most of the time cover fetching works and only sometimes fails.
I worked around this issue it in the pull request.
